### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ you have to install:
 
 on Debian/Ubuntu - you can use apt-get
 
+- on ubuntu you also need libtool 
+
+sudo apt-get install build-essential libtool
+
 on Mac - you can use tool brew from homebrew project. You have additionally install xcode. 
 
 ## Bug reporting and questions


### PR DESCRIPTION
add libtool install for debian


reason for that is next log from fetch.sh    

 libyuv/unit_test/math_test.cc
A    libyuv/unit_test/rotate_argb_test.cc
 U   libyuv
Checked out revision 1433.
./autogen.sh: 1: ./autogen.sh: libtoolize: not found
./autogen.sh: 55: test: -lt: argument expected
./autogen.sh: 59: test: -gt: argument expected
./autogen.sh: 67: test: -lt: argument expected
./autogen.sh: 71: test: -gt: argument expected
generating `configure.ac'
running `aclocal -I . --force'
running `libtoolize --force --copy --install'
./autogen.sh: 1: eval: libtoolize: not found
error while running `libtoolize --force --copy --install'
➜  jni git:(master)        
