### PR TITLE
Fixed libyuv path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = git://git.sv.gnu.org/freetype/freetype2.git
 [submodule "library-jni/jni/libyuv"]
 	path = library-jni/jni/libyuv
-	url = https://git.chromium.org/external/libyuv.git
+	url = https://chromium.googlesource.com/external/libyuv


### PR DESCRIPTION
External git module libyuv url was wrong which caused problems with project compilation.

It fixes #137 