### PR TITLE
Update the libyuv repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = git://git.sv.gnu.org/freetype/freetype2.git
 [submodule "library-jni/jni/libyuv"]
 	path = library-jni/jni/libyuv
-	url = https://git.chromium.org/external/libyuv.git
+	url = https://chromium.googlesource.com/external/libyuv


### PR DESCRIPTION
The libyuv repo url is out of date, cause build failed. and Fix https://github.com/appunite/AndroidFFmpeg/issues/139